### PR TITLE
Fixes as a result of review conducted on Slack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@
 Dosh is a Go library for representing and manipulating monetary values both
 in-process and on-the-wire.
 
-It adds "currency awareness" to the well-proven
+It adds "currency awareness" to the
 [github.com/shopspring/decimal](https://github.com/shopspring/decimal) package.

--- a/compare.go
+++ b/compare.go
@@ -31,7 +31,7 @@ func (a Amount) Cmp(b Amount) (c int) {
 //
 // It panics if a and b do not use the same currency.
 //
-// To check equality between to amounts that may have differing currencies, use
+// To check equality between two amounts that may have differing currencies, use
 // Identical() instead.
 func (a Amount) Equal(b Amount) bool {
 	assertSameCurrency(a, b)

--- a/compare_test.go
+++ b/compare_test.go
@@ -54,7 +54,7 @@ var _ = Describe("type Amount (comparison functions)", func() {
 
 	Describe("func IsNegative()", func() {
 		DescribeTable(
-			"returns true if the amount has a positive magnitude",
+			"returns true if the amount has a negative magnitude",
 			func(dec string, expect bool) {
 				Expect(MustParse("XYZ", dec).IsNegative()).To(Equal(expect))
 			},

--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,5 @@
 // Package dosh represents and manipualtes monetary values both in-process
 // and on-the-wire.
 //
-// It adds "currency awareness" to the wel-proven
-// github.com/shopspring/decimal package.
+// It adds "currency awareness" to the github.com/shopspring/decimal package.
 package dosh

--- a/marshaljson_test.go
+++ b/marshaljson_test.go
@@ -72,12 +72,12 @@ var _ = Describe("type Amount (JSON marshaling)", func() {
 			),
 			Entry(
 				"units positive, nanos negative",
-				`{"currency_code": "XYZ", "units": 1, "nanos": -1}`,
+				`{"currency_code": "XYZ", "units": "1", "nanos": -1}`,
 				"cannot unmarshal amount from JSON representation: units and nanos components must have the same sign",
 			),
 			Entry(
 				"units negative, nanos positive",
-				`{"currency_code": "XYZ", "units": -1, "nanos": 1}`,
+				`{"currency_code": "XYZ", "units": "-1", "nanos": 1}`,
 				"cannot unmarshal amount from JSON representation: units and nanos components must have the same sign",
 			),
 		)

--- a/marshaljson_test.go
+++ b/marshaljson_test.go
@@ -58,12 +58,18 @@ var _ = Describe("type Amount (JSON marshaling)", func() {
 			func(data string, expect string) {
 				var a Amount
 				err := a.UnmarshalJSON([]byte(data))
-				Expect(err).To(MatchError(expect))
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).To(MatchRegexp(expect))
 			},
 			Entry(
 				"malformed JSON",
 				`<invalid>`,
-				"cannot unmarshal amount from JSON representation: proto:\u00a0syntax error (line 1:1): invalid value <",
+				// Note, protocol buffers package randomly emits different
+				// output to avoid code that checks errors by string value,
+				// which is fair enough but makes simple tests like this
+				// incredibly frustrating. This is the reason for the use of
+				// regular expressions.
+				"cannot unmarshal amount from JSON representation: proto:.+syntax error",
 			),
 			Entry(
 				"empty currency",

--- a/marshalproto_test.go
+++ b/marshalproto_test.go
@@ -38,7 +38,7 @@ var _ = Describe("type Amount (protocol buffers marshaling)", func() {
 				"cannot marshal amount to protocol buffers representation: magnitude's integer component overflows int64",
 			),
 			Entry(
-				"fractional component of the magnitude requires more precision that available",
+				"fractional component of the magnitude requires more precision than available",
 				MustParse("xyz", "0.0123456789"),
 				"cannot marshal amount to protocol buffers representation: magnitude's fractional component has too many decimal places",
 			),

--- a/marshaltext.go
+++ b/marshaltext.go
@@ -13,7 +13,7 @@ func (a Amount) MarshalText() (text []byte, err error) {
 	return []byte(a.String()), nil
 }
 
-// UnmarshalText unmarshals an amount from its protocol buffers representation.
+// UnmarshalText unmarshals an amount from its text representation.
 //
 // NOTE: In order to comply with Go's encoding.TextUnmarshaler interface, this
 // method mutates the internals of a, violating Amount's immutability guarantee.
@@ -22,7 +22,7 @@ func (a *Amount) UnmarshalText(text []byte) error {
 	parts := strings.SplitN(str, " ", 2)
 
 	if len(parts) != 2 {
-		return errors.New("cannot unmarshal amount from text representation: data must have current and magnitude components")
+		return errors.New("cannot unmarshal amount from text representation: data must have currency and magnitude components")
 	}
 
 	m, err := decimal.NewFromString(parts[1])

--- a/marshaltext_test.go
+++ b/marshaltext_test.go
@@ -39,9 +39,9 @@ var _ = Describe("type Amount (text marshaling)", func() {
 				err := a.UnmarshalText([]byte(data))
 				Expect(err).To(MatchError(expect))
 			},
-			Entry("empty", "", "cannot unmarshal amount from text representation: data must have current and magnitude components"),
-			Entry("empty currency", " 1.23", "cannot unmarshal amount from text representation: data must have current and magnitude components"),
-			Entry("empty magnitude", "XYZ ", "cannot unmarshal amount from text representation: data must have current and magnitude components"),
+			Entry("empty", "", "cannot unmarshal amount from text representation: data must have currency and magnitude components"),
+			Entry("empty currency", " 1.23", "cannot unmarshal amount from text representation: data must have currency and magnitude components"),
+			Entry("empty magnitude", "XYZ ", "cannot unmarshal amount from text representation: data must have currency and magnitude components"),
 			Entry("invalid magnitude", "XYZ <invalid>", "cannot unmarshal amount from text representation: can't convert <invalid> to decimal"),
 		)
 	})

--- a/math.go
+++ b/math.go
@@ -4,7 +4,8 @@ import "github.com/shopspring/decimal"
 
 // Abs returns the absolute value of this amount.
 //
-// That is, if a < 0 it returns -a. Otherwise it returns a unchanged.
+// That is, if a is negative, it returns its inverse (a positive magnitude),
+// otherwise it returns a unchanged.
 func (a Amount) Abs() Amount {
 	a.mag = a.mag.Abs()
 	return a

--- a/math_test.go
+++ b/math_test.go
@@ -95,6 +95,12 @@ var _ = Describe("type Amount (math methods)", func() {
 				a.Div(b)
 			}).To(PanicWith("can not operate on amounts in differing currencies (XYZ vs ABC)"))
 		})
+
+		It("panics when dividing by zero", func() {
+			Expect(func() {
+				Amount{}.Div(Amount{})
+			}).To(PanicWith("decimal division by 0"))
+		})
 	})
 
 	Describe("func DivScalar()", func() {
@@ -103,6 +109,12 @@ var _ = Describe("type Amount (math methods)", func() {
 			b := decimal.RequireFromString("0.5")
 			x := MustParse("XYZ", "2.46")
 			Expect(a.DivScalar(b).Equal(x)).To(BeTrue())
+		})
+
+		It("panics when dividing by zero", func() {
+			Expect(func() {
+				Amount{}.DivScalar(decimal.Decimal{})
+			}).To(PanicWith("decimal division by 0"))
 		})
 	})
 
@@ -121,6 +133,12 @@ var _ = Describe("type Amount (math methods)", func() {
 				a.Mod(b)
 			}).To(PanicWith("can not operate on amounts in differing currencies (XYZ vs ABC)"))
 		})
+
+		It("panics when dividing by zero", func() {
+			Expect(func() {
+				Amount{}.Mod(Amount{})
+			}).To(PanicWith("decimal division by 0"))
+		})
 	})
 
 	Describe("func ModScalar()", func() {
@@ -129,6 +147,12 @@ var _ = Describe("type Amount (math methods)", func() {
 			b := decimal.RequireFromString("0.5")
 			x := MustParse("XYZ", "0.23")
 			Expect(a.ModScalar(b).Equal(x)).To(BeTrue())
+		})
+
+		It("panics when dividing by zero", func() {
+			Expect(func() {
+				Amount{}.ModScalar(decimal.Decimal{})
+			}).To(PanicWith("decimal division by 0"))
 		})
 	})
 })


### PR DESCRIPTION
I've addressed everything you guys mentioned, thanks!

A few responses to specific things below ...

# confusing documentation on `Abs()` 

@danilvpetrov:

> https://github.com/dogmatiq/dosh/blob/main/math.go#L7
>
> IMHO, this line of comments is redundant and might even be confusing with -a. Absolute value is always positive.

I always try to describe what a function does, even if it uses fairly standard terminology.  Without this line of text, the documentation just says `Abs returns the absolute value of this amount.` which doesn't tell you anything unless you already know what it means.

I have reworded this line though, LMK if you think it's any better.

# division by zero

@danilvpetrov:

> https://github.com/dogmatiq/dosh/blob/main/math.go#L43-L47
>
> I think this should also panic if devision by zero is attempted.
> Same goes for this method: https://github.com/dogmatiq/dosh/blob/main/math.go#L53-L55
> I think devision by zero should also cause panicking in all `.Mod*()` methods too.

This is a good catch, I checked and this is already handled by the methods on `shopspring/decimal`, so I didn't change any of the implementation, but I did add tests for it.

# empty currency code

@kodenkm:

> When can the currency code be empty?
> It says this:
> ```
> // An empty string is equivalent to "USD".`
> ```
> But then denies it?
> ```
> func New(c string, m decimal.Decimal) Amount {
>	if c == "" {
>		panic("currency code must not be empty")
> ```
> I guess you can create the values without using the New() in Go.

That's right, those docs are from the internal field, and you can see the behavior here:

```go
func (a Amount) CurrencyCode() string {
	if a.cur == "" {
		return "USD"
	}

	return a.cur
}
```

This is done in order to [make the zero-value useful](https://dave.cheney.net/practical-go/presentations/gophercon-israel.html#_make_the_zero_value_useful).
