### PR TITLE
Strict currency code validation.

### DIFF
--- a/amount.go
+++ b/amount.go
@@ -2,8 +2,8 @@ package dosh
 
 import (
 	"fmt"
-	"strings"
 
+	"github.com/dogmatiq/dosh/internal/currency"
 	"github.com/shopspring/decimal"
 )
 
@@ -38,45 +38,49 @@ type Amount struct {
 
 // New returns an Amount with a specific currency and magnitude.
 //
-// c is the currency code that identifies the currency. It SHOULD be an ISO-4217
-// 3-letter code if the currency is defined by ISO-4217. Non-standard currency
-// codes SHOULD begin with an "X". All values are converted to uppercase.
+// c is the currency code that identifies the currency. It must consist only of
+// uppercase ASCII letters and have a minimum length of 3. It SHOULD be an
+// ISO-4217 3-letter code where applicable. Non-standard currency codes SHOULD
+// begin with an "X".
 //
 // m is the magnitude of the amount, expressed in the currency specified by c.
 func New(c string, m decimal.Decimal) Amount {
-	if c == "" {
-		panic("currency code must not be empty")
+	if err := currency.ValidateCode(c); err != nil {
+		panic(err)
 	}
 
 	return Amount{
-		cur: strings.ToUpper(c),
+		cur: c,
 		mag: m,
 	}
 }
 
 // Zero returns an Amount with a magnitude of 0 (zero) in a specific currency.
 //
-// c is the currency code that identifies the currency. It SHOULD be an ISO-4217
-// 3-letter code if the currency is defined by ISO-4217. Non-standard currency
-// codes SHOULD begin with an "X". All values are converted to uppercase.
+// c is the currency code that identifies the currency. It must consist only of
+// uppercase ASCII letters and have a minimum length of 3. It SHOULD be an
+// ISO-4217 3-letter code where applicable. Non-standard currency codes SHOULD
+// begin with an "X".
 func Zero(c string) Amount {
 	return New(c, zero)
 }
 
 // Unit returns an Amount with a magnitude of 1 (one) in a specific currency.
 //
-// c is the currency code that identifies the currency. It SHOULD be an ISO-4217
-// 3-letter code if the currency is defined by ISO-4217. Non-standard currency
-// codes SHOULD begin with an "X". All values are converted to uppercase.
+// c is the currency code that identifies the currency. It must consist only of
+// uppercase ASCII letters and have a minimum length of 3. It SHOULD be an
+// ISO-4217 3-letter code where applicable. Non-standard currency codes SHOULD
+// begin with an "X".
 func Unit(c string) Amount {
 	return New(c, unit)
 }
 
 // Int returns an Amount with an integer magnitude in a specific currency.
 //
-// c is the currency code that identifies the currency. It SHOULD be an ISO-4217
-// 3-letter code if the currency is defined by ISO-4217. Non-standard currency
-// codes SHOULD begin with an "X". All values are converted to uppercase.
+// c is the currency code that identifies the currency. It must consist only of
+// uppercase ASCII letters and have a minimum length of 3. It SHOULD be an
+// ISO-4217 3-letter code where applicable. Non-standard currency codes SHOULD
+// begin with an "X".
 //
 // m is the magnitude of the amount, expressed in the currency specified by c.
 func Int(c string, m int) Amount {
@@ -85,9 +89,10 @@ func Int(c string, m int) Amount {
 
 // Parse returns a new Amount with a magnitude parsed from a decimal string.
 //
-// c is the currency code that identifies the currency. It SHOULD be an ISO-4217
-// 3-letter code if the currency is defined by ISO-4217. Non-standard currency
-// codes SHOULD begin with an "X". All values are converted to uppercase.
+// c is the currency code that identifies the currency. It must consist only of
+// uppercase ASCII letters and have a minimum length of 3. It SHOULD be an
+// ISO-4217 3-letter code where applicable. Non-standard currency codes SHOULD
+// begin with an "X".
 //
 // m is the string representation of an integer or decimal number, expressed in
 // the currency specified by c.
@@ -103,9 +108,10 @@ func Parse(c, m string) (Amount, error) {
 // MustParse returns a new Amount with a magnitude parsed from a decimal string
 // or panics if unable to do so.
 //
-// c is the currency code that identifies the currency. It SHOULD be an ISO-4217
-// 3-letter code if the currency is defined by ISO-4217. Non-standard currency
-// codes SHOULD begin with an "X". All values are converted to uppercase.
+// c is the currency code that identifies the currency. It must consist only of
+// uppercase ASCII letters and have a minimum length of 3. It SHOULD be an
+// ISO-4217 3-letter code where applicable. Non-standard currency codes SHOULD
+// begin with an "X".
 //
 // m is the string representation of an integer or decimal number, expressed in
 // the currency specified by c.
@@ -118,8 +124,6 @@ func MustParse(c, m string) Amount {
 
 // CurrencyCode returns the currency code for the currency in which the amount
 // is specified.
-//
-// The returned currency code is always uppercase.
 func (a Amount) CurrencyCode() string {
 	if len(a.cur) == 0 {
 		return "USD"

--- a/amount_test.go
+++ b/amount_test.go
@@ -14,69 +14,69 @@ var _ = Describe("type Amount", func() {
 	Describe("func New()", func() {
 		It("returns an amount with the correct currency code and magnitude", func() {
 			m := decimal.NewFromInt(123)
-			a := New("xyz", m)
-			Expect(a.CurrencyCode()).To(Equal("XYZ")) // note: uppercase
+			a := New("XYZ", m)
+			Expect(a.CurrencyCode()).To(Equal("XYZ"))
 			Expect(a.Magnitude().Equal(m))
 		})
 
-		It("panics if the currency code is empty", func() {
+		It("panics if the currency code is invalid", func() {
 			Expect(func() {
-				New("", decimal.Decimal{})
-			}).To(PanicWith("currency code must not be empty"))
+				New("X", decimal.Decimal{})
+			}).To(PanicWith(MatchError("currency code (X) is invalid, codes must consist only of 3 or more uppercase ASCII letters")))
 		})
 	})
 
 	Describe("func Zero()", func() {
 		It("returns an amount with the correct currency code and magnitude", func() {
-			a := Zero("xyz")
-			Expect(a.CurrencyCode()).To(Equal("XYZ")) // note: uppercase
+			a := Zero("XYZ")
+			Expect(a.CurrencyCode()).To(Equal("XYZ"))
 			Expect(a.Magnitude().IsZero()).To(BeTrue())
 		})
 
-		It("panics if the currency code is empty", func() {
+		It("panics if the currency code is invalid", func() {
 			Expect(func() {
-				Zero("")
-			}).To(PanicWith("currency code must not be empty"))
+				Zero("X")
+			}).To(PanicWith(MatchError("currency code (X) is invalid, codes must consist only of 3 or more uppercase ASCII letters")))
 		})
 	})
 
 	Describe("func Unit()", func() {
 		It("returns an amount with the correct currency code and magnitude", func() {
-			a := Unit("xyz")
-			Expect(a.CurrencyCode()).To(Equal("XYZ")) // note: uppercase
+			a := Unit("XYZ")
+			Expect(a.CurrencyCode()).To(Equal("XYZ"))
 
 			m := decimal.NewFromInt(1)
 			Expect(a.Magnitude().Equal(m)).To(BeTrue())
 		})
 
-		It("panics if the currency code is empty", func() {
+		It("panics if the currency code is invalid", func() {
 			Expect(func() {
-				Zero("")
-			}).To(PanicWith("currency code must not be empty"))
+				Unit("X")
+			}).To(PanicWith(MatchError("currency code (X) is invalid, codes must consist only of 3 or more uppercase ASCII letters")))
 		})
 	})
 
 	Describe("func Int()", func() {
 		It("returns an amount with the correct currency code and magnitude", func() {
-			a := Int("xyz", 123)
-			Expect(a.CurrencyCode()).To(Equal("XYZ")) // note: uppercase
+			a := Int("XYZ", 123)
+			Expect(a.CurrencyCode()).To(Equal("XYZ"))
 
 			m := decimal.NewFromInt(123)
 			Expect(a.Magnitude().Equal(m)).To(BeTrue())
 		})
 
-		It("panics if the currency code is empty", func() {
+		It("panics if the currency code is invalid", func() {
 			Expect(func() {
-				Int("", 0)
-			}).To(PanicWith("currency code must not be empty"))
+				Int("X", 0)
+			}).To(PanicWith(MatchError("currency code (X) is invalid, codes must consist only of 3 or more uppercase ASCII letters")))
 		})
 	})
 
 	Describe("func Parse()", func() {
 		It("returns an amount with the correct currency code and magnitude", func() {
-			a, err := Parse("xyz", "1.23")
+			a, err := Parse("XYZ", "1.23")
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(a.CurrencyCode()).To(Equal("XYZ")) // note: uppercase
+			Expect(a.CurrencyCode()).To(Equal("XYZ"))
 
 			m := decimal.RequireFromString("1.23")
 			Expect(a.Magnitude().Equal(m)).To(BeTrue())
@@ -87,17 +87,17 @@ var _ = Describe("type Amount", func() {
 			Expect(err).Should(HaveOccurred())
 		})
 
-		It("panics if the currency code is empty", func() {
+		It("panics if the currency code is invalid", func() {
 			Expect(func() {
-				Parse("", "1.23")
-			}).To(PanicWith("currency code must not be empty"))
+				Parse("X", "1.23")
+			}).To(PanicWith(MatchError("currency code (X) is invalid, codes must consist only of 3 or more uppercase ASCII letters")))
 		})
 	})
 
 	Describe("func MustParse()", func() {
 		It("returns an amount with the correct currency code and magnitude", func() {
-			a := MustParse("xyz", "1.23")
-			Expect(a.CurrencyCode()).To(Equal("XYZ")) // note: uppercase
+			a := MustParse("XYZ", "1.23")
+			Expect(a.CurrencyCode()).To(Equal("XYZ"))
 
 			m := decimal.RequireFromString("1.23")
 			Expect(a.Magnitude().Equal(m)).To(BeTrue())
@@ -109,22 +109,22 @@ var _ = Describe("type Amount", func() {
 			}).To(Panic())
 		})
 
-		It("panics if the currency code is empty", func() {
+		It("panics if the currency code is invalid", func() {
 			Expect(func() {
-				MustParse("", "1.23")
-			}).To(PanicWith("currency code must not be empty"))
+				MustParse("X", "1.23")
+			}).To(PanicWith(MatchError("currency code (X) is invalid, codes must consist only of 3 or more uppercase ASCII letters")))
 		})
 	})
 
 	Describe("func CurrencyCode()", func() {
+		It("returns the currency code", func() {
+			a := Zero("XYZ")
+			Expect(a.CurrencyCode()).To(Equal("XYZ"))
+		})
+
 		It("returns USD when called on a zero-value amount", func() {
 			var a Amount
 			Expect(a.CurrencyCode()).To(Equal("USD"))
-		})
-
-		It("returns the provided code in upper case", func() {
-			a := Zero("xyz")
-			Expect(a.CurrencyCode()).To(Equal("XYZ"))
 		})
 	})
 
@@ -143,7 +143,7 @@ var _ = Describe("type Amount", func() {
 
 	Describe("func String()", func() {
 		It("returns a string representation of the amount", func() {
-			a := MustParse("xyz", "10.123")
+			a := MustParse("XYZ", "10.123")
 			Expect(a.String()).To(Equal("XYZ 10.123"))
 		})
 	})
@@ -155,21 +155,21 @@ var _ = Describe("type Amount", func() {
 				Expect(a.GoString()).To(Equal(expect))
 			},
 			Entry("zero-value", Amount{}, `money.Zero("USD")`),
-			Entry("zero-magnitude", Zero("xyz"), `money.Zero("XYZ")`),
-			Entry("unit-magnitude", Unit("xyz"), `money.Unit("XYZ")`),
-			Entry("other", MustParse("xyz", "1.23"), `money.MustParse("XYZ", "1.23")`),
+			Entry("zero-magnitude", Zero("XYZ"), `money.Zero("XYZ")`),
+			Entry("unit-magnitude", Unit("XYZ"), `money.Unit("XYZ")`),
+			Entry("other", MustParse("XYZ", "1.23"), `money.MustParse("XYZ", "1.23")`),
 		)
 	})
 
 	Describe("func Format()", func() {
 		It("returns a formatted representation of the amount", func() {
-			a := MustParse("xyz", "10.129")
+			a := MustParse("XYZ", "10.129")
 			s := fmt.Sprintf("%0.2f", a)
 			Expect(s).To(Equal("XYZ 10.13"))
 		})
 
 		It("returns a descriptive string if used with an unsupported verb", func() {
-			a := MustParse("xyz", "10.129")
+			a := MustParse("XYZ", "10.129")
 			s := fmt.Sprintf("%d", a)
 			Expect(s).To(Equal("%!d(money.Amount=XYZ 10.129)"))
 		})

--- a/compare_test.go
+++ b/compare_test.go
@@ -215,21 +215,21 @@ var _ = Describe("type Amount (comparison functions)", func() {
 	Describe("func LexicallyLessThan()", func() {
 		It("allows for lexical sorting of amounts by currency, then value", func() {
 			shuffled := []Amount{
-				MustParse("A", "1"),
-				MustParse("B", "-1"),
-				MustParse("B", "1"),
-				MustParse("B", "0"),
-				MustParse("A", "0"),
-				MustParse("A", "-1"),
+				MustParse("XXA", "1"),
+				MustParse("XXB", "-1"),
+				MustParse("XXB", "1"),
+				MustParse("XXB", "0"),
+				MustParse("XXA", "0"),
+				MustParse("XXA", "-1"),
 			}
 
 			sorted := []Amount{
-				MustParse("A", "-1"),
-				MustParse("A", "0"),
-				MustParse("A", "1"),
-				MustParse("B", "-1"),
-				MustParse("B", "0"),
-				MustParse("B", "1"),
+				MustParse("XXA", "-1"),
+				MustParse("XXA", "0"),
+				MustParse("XXA", "1"),
+				MustParse("XXB", "-1"),
+				MustParse("XXB", "0"),
+				MustParse("XXB", "1"),
 			}
 
 			sort.Slice(

--- a/internal/currency/ginkgo_test.go
+++ b/internal/currency/ginkgo_test.go
@@ -1,0 +1,15 @@
+package currency_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	type tag struct{}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, reflect.TypeOf(tag{}).PkgPath())
+}

--- a/internal/currency/validate.go
+++ b/internal/currency/validate.go
@@ -1,0 +1,36 @@
+package currency
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ValidateCode returns an error if s is not a valid currency code.
+//
+// A valid currency code is a minimum of 3 characters long, and consists
+// entirely of uppercase ASCII letters.
+func ValidateCode(c string) error {
+	if len(c) == 0 {
+		return errors.New("currency code is empty, codes must consist only of 3 or more uppercase ASCII letters")
+	}
+
+	if len(c) >= 3 && isUppercaseASCII(c) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"currency code (%s) is invalid, codes must consist only of 3 or more uppercase ASCII letters",
+		c,
+	)
+}
+
+// isUppercaseASCII returns true if c consists only of uppercase ASCII letters.
+func isUppercaseASCII(c string) bool {
+	for _, r := range c {
+		if r < 'A' || r > 'Z' {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/currency/validate.go
+++ b/internal/currency/validate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// ValidateCode returns an error if s is not a valid currency code.
+// ValidateCode returns an error if c is not a valid currency code.
 //
 // A valid currency code is a minimum of 3 characters long, and consists
 // entirely of uppercase ASCII letters.

--- a/internal/currency/validate_test.go
+++ b/internal/currency/validate_test.go
@@ -1,0 +1,33 @@
+package currency_test
+
+import (
+	. "github.com/dogmatiq/dosh/internal/currency"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func ValidateCode()", func() {
+	DescribeTable(
+		"returns nil if the currency code is valid",
+		func(c string) {
+			err := ValidateCode(c)
+			Expect(err).ShouldNot(HaveOccurred())
+		},
+		Entry("ISO-4217 code", "USD"),
+		Entry("non-standard code", "XYZ"),
+		Entry("non-standard code longer than 3 characters", "XYZXX"),
+		Entry("non-standard code longer than 3 characters, without leading X", "ABCXX"),
+	)
+
+	DescribeTable(
+		"returns an error if the currency code is invalid",
+		func(c, expect string) {
+			err := ValidateCode(c)
+			Expect(err).To(MatchError(expect))
+		},
+		Entry("empty", "", "currency code is empty, codes must consist only of 3 or more uppercase ASCII letters"),
+		Entry("too short", "X", "currency code (X) is invalid, codes must consist only of 3 or more uppercase ASCII letters"),
+		Entry("non-letters", "XY9", "currency code (XY9) is invalid, codes must consist only of 3 or more uppercase ASCII letters"),
+	)
+})

--- a/marshalbinary_test.go
+++ b/marshalbinary_test.go
@@ -7,12 +7,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/shopspring/decimal"
 )
 
 var _ = Describe("type Amount (binary marshaling)", func() {
 	Describe("func MarshalBinary() and UnmarshalBinary()", func() {
 		It("marshals and unmarshals an amount", func() {
-			a := MustParse("xyz", "10.123")
+			a := MustParse("XYZ", "10.123")
 
 			data, err := a.MarshalBinary()
 			Expect(err).ShouldNot(HaveOccurred())
@@ -33,6 +34,21 @@ var _ = Describe("type Amount (binary marshaling)", func() {
 		})
 	})
 
+	// binaryZero is the binary representation of a decimal with a value of 0.
+	//
+	// This is built inline (as opposed to in BeforeEach) because it is used
+	// within a call to Entry().
+	var binaryZero string
+
+	{
+		data, err := decimal.Decimal{}.MarshalBinary()
+		if err != nil {
+			panic(err)
+		}
+
+		binaryZero = string(data)
+	}
+
 	Describe("func UnmarshalBinary()", func() {
 		DescribeTable(
 			"it returns an error if the data is invalid",
@@ -48,8 +64,13 @@ var _ = Describe("type Amount (binary marshaling)", func() {
 			),
 			Entry(
 				"empty currency",
-				"\x00",
-				"cannot unmarshal amount from binary representation: currency component is empty",
+				"\x00"+binaryZero,
+				"cannot unmarshal amount from binary representation: currency code is empty, codes must consist only of 3 or more uppercase ASCII letters",
+			),
+			Entry(
+				"invalid currency",
+				"\x01X"+binaryZero,
+				"cannot unmarshal amount from binary representation: currency code (X) is invalid, codes must consist only of 3 or more uppercase ASCII letters",
 			),
 			Entry(
 				"empty magnitude",

--- a/marshalproto_test.go
+++ b/marshalproto_test.go
@@ -15,12 +15,12 @@ import (
 var _ = Describe("type Amount (protocol buffers marshaling)", func() {
 	Describe("func MarshalProto()", func() {
 		It("returns the protocol buffers representation of the amount", func() {
-			a := MustParse("xyz", "10.123")
+			a := MustParse("XYZ", "10.123")
 
 			pb, err := a.MarshalProto()
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(pb).To(EqualX(&money.Money{
-				CurrencyCode: "XYZ", // note: uppercase
+				CurrencyCode: "XYZ",
 				Units:        10,
 				Nanos:        123000000,
 			}))
@@ -34,12 +34,12 @@ var _ = Describe("type Amount (protocol buffers marshaling)", func() {
 			},
 			Entry(
 				"integer component of the magnitude overflows an int64",
-				Int("xyz", math.MaxInt64).Add(Unit("xyz")),
+				Int("XYZ", math.MaxInt64).Add(Unit("XYZ")),
 				"cannot marshal amount to protocol buffers representation: magnitude's integer component overflows int64",
 			),
 			Entry(
 				"fractional component of the magnitude requires more precision than available",
-				MustParse("xyz", "0.0123456789"),
+				MustParse("XYZ", "0.0123456789"),
 				"cannot marshal amount to protocol buffers representation: magnitude's fractional component has too many decimal places",
 			),
 		)
@@ -50,12 +50,12 @@ var _ = Describe("type Amount (protocol buffers marshaling)", func() {
 			var a Amount
 
 			err := a.UnmarshalProto(&money.Money{
-				CurrencyCode: "xyz",
+				CurrencyCode: "XYZ",
 				Units:        10,
 				Nanos:        123000000,
 			})
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(a.CurrencyCode()).To(Equal("XYZ")) // note: uppercase
+			Expect(a.CurrencyCode()).To(Equal("XYZ"))
 
 			m := decimal.RequireFromString("10.123")
 			Expect(a.Magnitude().Equal(m))
@@ -71,7 +71,12 @@ var _ = Describe("type Amount (protocol buffers marshaling)", func() {
 			Entry(
 				"empty currency",
 				&money.Money{},
-				"cannot unmarshal amount from protocol buffers representation: currency code must not be empty",
+				"cannot unmarshal amount from protocol buffers representation: currency code is empty, codes must consist only of 3 or more uppercase ASCII letters",
+			),
+			Entry(
+				"invalid currency",
+				&money.Money{CurrencyCode: "X"},
+				"cannot unmarshal amount from protocol buffers representation: currency code (X) is invalid, codes must consist only of 3 or more uppercase ASCII letters",
 			),
 			Entry(
 				"units positive, nanos negative",

--- a/marshaltext.go
+++ b/marshaltext.go
@@ -1,10 +1,12 @@
 package dosh
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/dogmatiq/dosh/internal/currency"
 	"github.com/shopspring/decimal"
 )
 
@@ -18,20 +20,32 @@ func (a Amount) MarshalText() (text []byte, err error) {
 // NOTE: In order to comply with Go's encoding.TextUnmarshaler interface, this
 // method mutates the internals of a, violating Amount's immutability guarantee.
 func (a *Amount) UnmarshalText(text []byte) error {
-	str := strings.TrimSpace(string(text))
-	parts := strings.SplitN(str, " ", 2)
-
-	if len(parts) != 2 {
-		return errors.New("cannot unmarshal amount from text representation: data must have currency and magnitude components")
+	n := bytes.IndexRune(text, ' ')
+	if n == -1 {
+		return errors.New("cannot unmarshal amount from text representation: data must have currency and magnitude components separated by a single space")
 	}
 
-	m, err := decimal.NewFromString(parts[1])
-	if err != nil {
+	c := string(text[:n])
+	m := string(text[n+1:])
+
+	if err := currency.ValidateCode(c); err != nil {
 		return fmt.Errorf("cannot unmarshal amount from text representation: %w", err)
 	}
 
-	a.cur = strings.ToUpper(parts[0])
-	a.mag = m
+	d, err := decimal.NewFromString(m)
+	if err != nil {
+		if strings.TrimSpace(m) == "" {
+			// Provide a slightly less-cryptic error message when the magnitude
+			// consists solely of whitespace. Otherwise, we get an error like
+			// "can't convert  to decimal".
+			return errors.New("cannot unmarshal amount from text representation: cannot parse magnitude")
+		}
+
+		return fmt.Errorf("cannot unmarshal amount from text representation: %w", err)
+	}
+
+	a.cur = c
+	a.mag = d
 
 	return nil
 }

--- a/marshaltext_test.go
+++ b/marshaltext_test.go
@@ -11,11 +11,11 @@ import (
 var _ = Describe("type Amount (text marshaling)", func() {
 	Describe("func MarshalText()", func() {
 		It("returns a textual representation of the amount", func() {
-			a := MustParse("xyz", "10.123")
+			a := MustParse("XYZ", "10.123")
 
 			data, err := a.MarshalText()
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(data).To(Equal([]byte("XYZ 10.123"))) // note: uppercase
+			Expect(data).To(Equal([]byte("XYZ 10.123")))
 		})
 	})
 
@@ -23,10 +23,10 @@ var _ = Describe("type Amount (text marshaling)", func() {
 		It("unmarshals an amount from its textual representation", func() {
 			var a Amount
 
-			data := []byte("xyz 10.123")
+			data := []byte("XYZ 10.123")
 			err := a.UnmarshalText(data)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(a.CurrencyCode()).To(Equal("XYZ")) // note: uppercase
+			Expect(a.CurrencyCode()).To(Equal("XYZ"))
 
 			m := decimal.RequireFromString("10.123")
 			Expect(a.Magnitude().Equal(m))
@@ -39,9 +39,10 @@ var _ = Describe("type Amount (text marshaling)", func() {
 				err := a.UnmarshalText([]byte(data))
 				Expect(err).To(MatchError(expect))
 			},
-			Entry("empty", "", "cannot unmarshal amount from text representation: data must have currency and magnitude components"),
-			Entry("empty currency", " 1.23", "cannot unmarshal amount from text representation: data must have currency and magnitude components"),
-			Entry("empty magnitude", "XYZ ", "cannot unmarshal amount from text representation: data must have currency and magnitude components"),
+			Entry("empty", "", "cannot unmarshal amount from text representation: data must have currency and magnitude components separated by a single space"),
+			Entry("empty currency", " 1.23", "cannot unmarshal amount from text representation: currency code is empty, codes must consist only of 3 or more uppercase ASCII letters"),
+			Entry("invalid currency", "X 1.23", "cannot unmarshal amount from text representation: currency code (X) is invalid, codes must consist only of 3 or more uppercase ASCII letters"),
+			Entry("empty magnitude", "XYZ ", "cannot unmarshal amount from text representation: cannot parse magnitude"),
 			Entry("invalid magnitude", "XYZ <invalid>", "cannot unmarshal amount from text representation: can't convert <invalid> to decimal"),
 		)
 	})


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR tightens the requirements on currency codes, requiring that they be at least 3 characters long and consist only of uppercase characters.

#### Why make this change?

To enforce something as close as possible to the ISO-4217 specification, while still allowing for custom currency codes.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
