### PR TITLE
Implement `protomoney` package.

### DIFF
--- a/protomoney/compare.go
+++ b/protomoney/compare.go
@@ -9,13 +9,13 @@ func IsZero(m *money.Money) bool {
 	return m.Units == 0 && m.Nanos == 0
 }
 
-// IsPositive returns true m has a positive magnitude.
+// IsPositive returns true if m has a positive magnitude.
 func IsPositive(m *money.Money) bool {
 	assertSignsAgree(m)
 	return m.Units > 0 || m.Nanos > 0
 }
 
-// IsNegative returns true m has a negative magnitude.
+// IsNegative returns true if m has a negative magnitude.
 func IsNegative(m *money.Money) bool {
 	assertSignsAgree(m)
 	return m.Units < 0 || m.Nanos < 0

--- a/protomoney/compare.go
+++ b/protomoney/compare.go
@@ -1,0 +1,146 @@
+package protomoney
+
+import (
+	"google.golang.org/genproto/googleapis/type/money"
+)
+
+// IsZero returns true if m has a magnitude of zero.
+func IsZero(m *money.Money) bool {
+	return m.Units == 0 && m.Nanos == 0
+}
+
+// IsPositive returns true m has a positive magnitude.
+func IsPositive(m *money.Money) bool {
+	assertSignsAgree(m)
+	return m.Units > 0 || m.Nanos > 0
+}
+
+// IsNegative returns true m has a negative magnitude.
+func IsNegative(m *money.Money) bool {
+	assertSignsAgree(m)
+	return m.Units < 0 || m.Nanos < 0
+}
+
+// Cmp compares a to b and returns a C-style comparison result.
+//
+// It panics if a and b do not use the same currency.
+//
+// If a < b then c is negative.
+// If a > b then c is positive.
+// Otherwise; a == b and c is zero.
+func Cmp(a, b *money.Money) (c int) {
+	assertSameCurrency(a, b)
+
+	a = normalize(a)
+	b = normalize(b)
+
+	if a.Units < b.Units {
+		return -1
+	}
+
+	if a.Units > b.Units {
+		return +1
+	}
+
+	return int(a.Nanos - b.Nanos)
+}
+
+// Equal returns true if a and b have the same magnitude.
+//
+// It panics if a and b do not use the same currency.
+//
+// To check equality between two amounts that may have differing currencies, use
+// IdenticalTo() instead.
+func EqualTo(a, b *money.Money) bool {
+	return Cmp(a, b) == 0
+}
+
+// Identical returns true if a and b use the same currency and have the same
+// magnitude.
+//
+// For general comparisons that are expected to be in the same currency, use
+// EqualTo() instead.
+func IdenticalTo(a, b *money.Money) bool {
+	if a.CurrencyCode != b.CurrencyCode {
+		return false
+	}
+
+	return Cmp(a, b) == 0
+}
+
+// LessThan returns true if a < b.
+//
+// It panics if a and b do not use the same currency.
+func LessThan(a, b *money.Money) bool {
+	return Cmp(a, b) < 0
+}
+
+// LessThanOrEqualTo returns true if a <= b.
+//
+// It panics if a and b do not use the same currency.
+func LessThanOrEqualTo(a, b *money.Money) bool {
+	return Cmp(a, b) <= 0
+}
+
+// GreaterThan returns true if a > b.
+//
+// It panics if a and b do not use the same currency.
+func GreaterThan(a, b *money.Money) bool {
+	return Cmp(a, b) > 0
+}
+
+// GreaterThanOrEqualTo returns true if a >= b.
+//
+// It panics if a and b do not use the same currency.
+func GreaterThanOrEqualTo(a, b *money.Money) bool {
+	return Cmp(a, b) >= 0
+}
+
+// LexicallyLessThan returns true if a should appear before b in a sorted list.
+//
+// There is no requirement that a and b use the same currency.
+func LexicallyLessThan(a, b *money.Money) bool {
+	if a.CurrencyCode == b.CurrencyCode {
+		return LessThan(a, b)
+	}
+
+	return a.CurrencyCode < b.CurrencyCode
+}
+
+// Min returns the smallest of the given amounts.
+//
+// It panics if amounts is empty, or if the amounts do not use the same
+// currency.
+func Min(amounts ...*money.Money) *money.Money {
+	if len(amounts) == 0 {
+		panic("at least one amount must be provided")
+	}
+
+	a := amounts[0]
+	for _, b := range amounts[1:] {
+		if LessThan(b, a) {
+			a = b
+		}
+	}
+
+	return a
+}
+
+// Max returns the largest of the given amounts.
+//
+// It panics if amounts is empty, or if the amounts do not use the same
+// currency.
+func Max(amounts ...*money.Money) *money.Money {
+	if len(amounts) == 0 {
+		panic("at least one amount must be provided")
+	}
+
+	a := amounts[0]
+	for _, b := range amounts[1:] {
+		if GreaterThan(b, a) {
+			a = b
+		}
+	}
+
+	return a
+}

--- a/protomoney/compare_test.go
+++ b/protomoney/compare_test.go
@@ -1,0 +1,383 @@
+package protomoney_test
+
+import (
+	"sort"
+
+	. "github.com/dogmatiq/dosh/protomoney"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"google.golang.org/genproto/googleapis/type/money"
+)
+
+var _ = Describe("func IsZero()", func() {
+	DescribeTable(
+		"it returns true if the amount has a magnitude of zero",
+		func(m *money.Money, expect bool) {
+			Expect(IsZero(m)).To(Equal(expect))
+		},
+		Entry("zero", &money.Money{}, true),
+		Entry("positive units", &money.Money{Units: 1}, false),
+		Entry("positive nanos", &money.Money{Nanos: 1}, false),
+		Entry("positive units & nanos", &money.Money{Units: 1, Nanos: 1}, false),
+		Entry("negative units", &money.Money{Units: -1}, false),
+		Entry("negative nanos", &money.Money{Nanos: -1}, false),
+		Entry("negative units & nanos", &money.Money{Units: -1, Nanos: -1}, false),
+	)
+})
+
+var _ = Describe("func IsPositive()", func() {
+	DescribeTable(
+		"it returns true if the amount has a positive magnitude",
+		func(m *money.Money, expect bool) {
+			Expect(IsPositive(m)).To(Equal(expect))
+		},
+		Entry("zero", &money.Money{}, false),
+		Entry("positive units", &money.Money{Units: 1}, true),
+		Entry("positive nanos", &money.Money{Nanos: 1}, true),
+		Entry("positive units & nanos", &money.Money{Units: 1, Nanos: 1}, true),
+		Entry("negative units", &money.Money{Units: -1}, false),
+		Entry("negative nanos", &money.Money{Nanos: -1}, false),
+		Entry("negative units & nanos", &money.Money{Units: -1, Nanos: -1}, false),
+	)
+})
+
+var _ = Describe("func IsNegative()", func() {
+	DescribeTable(
+		"it returns true if the amount has a negative magnitude",
+		func(m *money.Money, expect bool) {
+			Expect(IsNegative(m)).To(Equal(expect))
+		},
+		Entry("zero", &money.Money{}, false),
+		Entry("positive units", &money.Money{Units: 1}, false),
+		Entry("positive nanos", &money.Money{Nanos: 1}, false),
+		Entry("positive units & nanos", &money.Money{Units: 1, Nanos: 1}, false),
+		Entry("negative units", &money.Money{Units: -1}, true),
+		Entry("negative nanos", &money.Money{Nanos: -1}, true),
+		Entry("negative units & nanos", &money.Money{Units: -1, Nanos: -1}, true),
+	)
+})
+
+var _ = Context("comparison functions", func() {
+	vectors := []TableEntry{
+		Entry("equal, zero",
+			&money.Money{},
+			&money.Money{},
+			0,
+		),
+		Entry("equal, positive units",
+			&money.Money{Units: 1},
+			&money.Money{Units: 1},
+			0,
+		),
+		Entry("equal, positive nanos",
+			&money.Money{Nanos: 1},
+			&money.Money{Nanos: 1},
+			0,
+		),
+		Entry("equal, positive units & nanos",
+			&money.Money{Units: 1, Nanos: 1},
+			&money.Money{Units: 1, Nanos: 1},
+			0,
+		),
+		Entry("equal, positive, denormalized",
+			&money.Money{Units: 2, Nanos: 500000000},
+			&money.Money{Units: 1, Nanos: 1500000000},
+			0,
+		),
+		Entry("equal, negative units",
+			&money.Money{Units: -1},
+			&money.Money{Units: -1},
+			0,
+		),
+		Entry("equal, negative nanos",
+			&money.Money{Nanos: -1},
+			&money.Money{Nanos: -1},
+			0,
+		),
+		Entry("equal, negative units & nanos",
+			&money.Money{Units: -1, Nanos: -1},
+			&money.Money{Units: -1, Nanos: -1},
+			0,
+		),
+		Entry("equal, negative, denormalized",
+			&money.Money{Units: -2, Nanos: -500000000},
+			&money.Money{Units: -1, Nanos: -1500000000},
+			0,
+		),
+
+		Entry("less, zero",
+			&money.Money{},
+			&money.Money{Units: 1}, -1,
+		),
+		Entry("less, positive units",
+			&money.Money{Units: +1},
+			&money.Money{Units: +2}, -1,
+		),
+		Entry("less, positive nanos",
+			&money.Money{Nanos: +1},
+			&money.Money{Nanos: +2}, -1,
+		),
+		Entry("less, positive units & nanos",
+			&money.Money{Units: +1, Nanos: +1},
+			&money.Money{Units: +1, Nanos: +2}, -1,
+		),
+		Entry("less, negative units",
+			&money.Money{Units: -2},
+			&money.Money{Units: -1}, -1,
+		),
+		Entry("less, negative nanos",
+			&money.Money{Nanos: -2},
+			&money.Money{Nanos: +1}, -1,
+		),
+		Entry("less, negative units & nanos",
+			&money.Money{Units: -1, Nanos: -2},
+			&money.Money{Units: -1, Nanos: -1}, -1,
+		),
+		Entry("less, denormalized",
+			&money.Money{Units: 0, Nanos: 1500000000},
+			&money.Money{Units: 1, Nanos: 1500000000}, -1,
+		),
+	}
+
+	Describe("func Cmp()", func() {
+		DescribeTable(
+			"it returns a C-style comparison result",
+			func(a, b *money.Money, expect int) {
+				x := Cmp(a, b)
+				y := Cmp(b, a)
+
+				if expect == 0 {
+					Expect(x).To(BeZero())
+					Expect(y).To(BeZero())
+				} else {
+					Expect(x < 0).To(Equal(expect < 0))
+					Expect(y < 0).To(Equal(expect > 0))
+				}
+			},
+			vectors...,
+		)
+
+		It("panics if the amounts do not have the same currency", func() {
+			Expect(func() {
+				a := &money.Money{CurrencyCode: "XYZ"}
+				b := &money.Money{CurrencyCode: "ABC"}
+				Cmp(a, b)
+			}).To(PanicWith("can not operate on amounts in differing currencies (XYZ vs ABC)"))
+		})
+
+		It("panics if either of the operands units/nanos signs disagree", func() {
+			a := &money.Money{CurrencyCode: "XYZ", Units: 1, Nanos: -1}
+			b := &money.Money{CurrencyCode: "XYZ"}
+
+			Expect(func() {
+				Cmp(a, b)
+			}).To(PanicWith(MatchError("sign of units component (1) does not agree with sign of nanos component (-1)")))
+
+			Expect(func() {
+				Cmp(b, a)
+			}).To(PanicWith(MatchError("sign of units component (1) does not agree with sign of nanos component (-1)")))
+		})
+	})
+
+	Describe("func EqualTo()", func() {
+		DescribeTable(
+			"it returns true if the amounts have the same magnitude",
+			func(a, b *money.Money, expect int) {
+				Expect(EqualTo(a, b)).To(Equal(expect == 0))
+				Expect(EqualTo(b, a)).To(Equal(expect == 0))
+			},
+			vectors...,
+		)
+
+		It("panics if the amounts do not have the same currency", func() {
+			Expect(func() {
+				a := &money.Money{CurrencyCode: "XYZ"}
+				b := &money.Money{CurrencyCode: "ABC"}
+				EqualTo(a, b)
+			}).To(PanicWith("can not operate on amounts in differing currencies (XYZ vs ABC)"))
+		})
+	})
+
+	Describe("func IdenticalTo()", func() {
+		DescribeTable(
+			"it returns true if the amounts have the same currency and magnitude",
+			func(a, b *money.Money, expect int) {
+				Expect(IdenticalTo(a, b)).To(Equal(expect == 0))
+				Expect(IdenticalTo(b, a)).To(Equal(expect == 0))
+			},
+			vectors...,
+		)
+
+		It("returns false if the amounts have a different currency", func() {
+			a := &money.Money{CurrencyCode: "XYZ"}
+			b := &money.Money{CurrencyCode: "ABC"}
+			Expect(IdenticalTo(a, b)).To(BeFalse())
+		})
+	})
+
+	Describe("func LessThan()", func() {
+		DescribeTable(
+			"it returns true if a < b",
+			func(a, b *money.Money, expect int) {
+				Expect(LessThan(a, b)).To(Equal(expect < 0))
+				Expect(LessThan(b, a)).To(Equal(expect > 0))
+			},
+			vectors...,
+		)
+
+		It("panics if the amounts do not have the same currency", func() {
+			Expect(func() {
+				a := &money.Money{CurrencyCode: "XYZ"}
+				b := &money.Money{CurrencyCode: "ABC"}
+				LessThan(a, b)
+			}).To(PanicWith("can not operate on amounts in differing currencies (XYZ vs ABC)"))
+		})
+	})
+
+	Describe("func LessThanOrEqualTo()", func() {
+		DescribeTable(
+			"it returns true if a <= b",
+			func(a, b *money.Money, expect int) {
+				Expect(LessThanOrEqualTo(a, b)).To(Equal(expect <= 0))
+				Expect(LessThanOrEqualTo(b, a)).To(Equal(expect >= 0))
+			},
+			vectors...,
+		)
+
+		It("panics if the amounts do not have the same currency", func() {
+			Expect(func() {
+				a := &money.Money{CurrencyCode: "XYZ"}
+				b := &money.Money{CurrencyCode: "ABC"}
+				LessThanOrEqualTo(a, b)
+			}).To(PanicWith("can not operate on amounts in differing currencies (XYZ vs ABC)"))
+		})
+	})
+
+	Describe("func GreaterThan()", func() {
+		DescribeTable(
+			"it returns true if a > b",
+			func(a, b *money.Money, expect int) {
+				Expect(GreaterThan(a, b)).To(Equal(expect > 0))
+				Expect(GreaterThan(b, a)).To(Equal(expect < 0))
+			},
+			vectors...,
+		)
+
+		It("panics if the amounts do not have the same currency", func() {
+			Expect(func() {
+				a := &money.Money{CurrencyCode: "XYZ"}
+				b := &money.Money{CurrencyCode: "ABC"}
+				GreaterThan(a, b)
+			}).To(PanicWith("can not operate on amounts in differing currencies (XYZ vs ABC)"))
+		})
+	})
+
+	Describe("func GreaterThanOrEqualTo()", func() {
+		DescribeTable(
+			"it returns true if a >= b",
+			func(a, b *money.Money, expect int) {
+				Expect(GreaterThanOrEqualTo(a, b)).To(Equal(expect >= 0))
+				Expect(GreaterThanOrEqualTo(b, a)).To(Equal(expect <= 0))
+			},
+			vectors...,
+		)
+
+		It("panics if the amounts do not have the same currency", func() {
+			Expect(func() {
+				a := &money.Money{CurrencyCode: "XYZ"}
+				b := &money.Money{CurrencyCode: "ABC"}
+				GreaterThanOrEqualTo(a, b)
+			}).To(PanicWith("can not operate on amounts in differing currencies (XYZ vs ABC)"))
+		})
+	})
+})
+
+var _ = Describe("func LexicallyLessThan()", func() {
+	It("allows for lexical sorting of amounts by currency, then value", func() {
+		shuffled := []*money.Money{
+			{CurrencyCode: "XXA", Units: 1},
+			{CurrencyCode: "XXB", Units: -1},
+			{CurrencyCode: "XXB", Units: 1},
+			{CurrencyCode: "XXB", Units: 0},
+			{CurrencyCode: "XXA", Units: 0},
+			{CurrencyCode: "XXA", Units: -1},
+		}
+
+		sorted := []*money.Money{
+			{CurrencyCode: "XXA", Units: -1},
+			{CurrencyCode: "XXA", Units: 0},
+			{CurrencyCode: "XXA", Units: 1},
+			{CurrencyCode: "XXB", Units: -1},
+			{CurrencyCode: "XXB", Units: 0},
+			{CurrencyCode: "XXB", Units: 1},
+		}
+
+		sort.Slice(
+			shuffled,
+			func(i, j int) bool {
+				return LexicallyLessThan(shuffled[i], shuffled[j])
+			},
+		)
+
+		Expect(shuffled).To(Equal(sorted))
+	})
+})
+
+var _ = Describe("func Min()", func() {
+	It("returns the smallest of the given amounts", func() {
+		Expect(
+			Min(
+				&money.Money{CurrencyCode: "XYZ", Units: 2},
+				&money.Money{CurrencyCode: "XYZ", Units: 1},
+				&money.Money{CurrencyCode: "XYZ", Units: 3},
+			),
+		).To(Equal(
+			&money.Money{CurrencyCode: "XYZ", Units: 1},
+		))
+	})
+
+	It("panics if no amounts are provided", func() {
+		Expect(func() {
+			Min()
+		}).To(PanicWith("at least one amount must be provided"))
+	})
+
+	It("panics if the amounts do not have the same currency", func() {
+		Expect(func() {
+			Min(
+				&money.Money{CurrencyCode: "XYZ"},
+				&money.Money{CurrencyCode: "ABC"},
+			)
+		}).To(PanicWith("can not operate on amounts in differing currencies (ABC vs XYZ)"))
+	})
+})
+
+var _ = Describe("func Max()", func() {
+	It("returns the largest of the given amounts", func() {
+		Expect(
+			Max(
+				&money.Money{CurrencyCode: "XYZ", Units: 2},
+				&money.Money{CurrencyCode: "XYZ", Units: 1},
+				&money.Money{CurrencyCode: "XYZ", Units: 3},
+			),
+		).To(Equal(
+			&money.Money{CurrencyCode: "XYZ", Units: 3},
+		))
+	})
+
+	It("panics if no amounts are provided", func() {
+		Expect(func() {
+			Max()
+		}).To(PanicWith("at least one amount must be provided"))
+	})
+
+	It("panics if the amounts do not have the same currency", func() {
+		Expect(func() {
+			Max(
+				&money.Money{CurrencyCode: "XYZ"},
+				&money.Money{CurrencyCode: "ABC"},
+			)
+		}).To(PanicWith("can not operate on amounts in differing currencies (ABC vs XYZ)"))
+	})
+})

--- a/protomoney/doc.go
+++ b/protomoney/doc.go
@@ -1,0 +1,8 @@
+// Package protomoney provides basic, low-level mathematical and comparison
+// operations for the "well-known" protocol buffers Money type without
+// conversion to another data type.
+//
+// The functions in this package treat a *money.Money value as immutable.
+// Allocations are avoided as best possible, and minimal validation is
+// performed.
+package protomoney

--- a/protomoney/ginkgo_test.go
+++ b/protomoney/ginkgo_test.go
@@ -1,0 +1,15 @@
+package protomoney_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	type tag struct{}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, reflect.TypeOf(tag{}).PkgPath())
+}

--- a/protomoney/math.go
+++ b/protomoney/math.go
@@ -1,0 +1,81 @@
+package protomoney
+
+import (
+	"google.golang.org/genproto/googleapis/type/money"
+)
+
+// Abs returns the absolute value of this amount.
+//
+// That is, if m is negative, it returns its inverse (a positive magnitude),
+// otherwise it returns m unchanged.
+func Abs(m *money.Money) *money.Money {
+	if IsPositive(m) {
+		return m
+	}
+
+	return &money.Money{
+		CurrencyCode: m.CurrencyCode,
+		Units:        -m.Units,
+		Nanos:        -m.Nanos,
+	}
+}
+
+// Neg returns -m.
+func Neg(m *money.Money) *money.Money {
+	return &money.Money{
+		CurrencyCode: m.CurrencyCode,
+		Units:        -m.Units,
+		Nanos:        -m.Nanos,
+	}
+}
+
+// Add returns a + b.
+//
+// It panics if a and b do not use the same currency.
+func Add(a, b *money.Money) *money.Money {
+	assertSameCurrency(a, b)
+
+	m := &money.Money{
+		CurrencyCode: a.CurrencyCode,
+		Units:        a.Units + b.Units,
+		Nanos:        a.Nanos + b.Nanos,
+	}
+
+	normalizeInPlace(m)
+
+	return m
+}
+
+// Sub returns a - b.
+//
+// It panics if a and b do not use the same currency.
+func Sub(a, b *money.Money) *money.Money {
+	assertSameCurrency(a, b)
+
+	m := &money.Money{
+		CurrencyCode: a.CurrencyCode,
+		Units:        a.Units - b.Units,
+		Nanos:        a.Nanos - b.Nanos,
+	}
+
+	normalizeInPlace(m)
+
+	return m
+}
+
+// Sum returns the sum of the given amounts.
+//
+// It panics if amounts is empty, or if the amounts do not use the same
+// currency.
+func Sum(amounts ...*money.Money) *money.Money {
+	if len(amounts) == 0 {
+		panic("at least one amount must be provided")
+	}
+
+	a := amounts[0]
+	for _, b := range amounts[1:] {
+		a = Add(a, b)
+	}
+
+	return a
+}

--- a/protomoney/math_test.go
+++ b/protomoney/math_test.go
@@ -1,0 +1,96 @@
+package protomoney_test
+
+import (
+	. "github.com/dogmatiq/dosh/protomoney"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"google.golang.org/genproto/googleapis/type/money"
+)
+
+var _ = Describe("func Abs()", func() {
+	DescribeTable(
+		"it returns an amount with the absolute magnitude",
+		func(m, expect *money.Money) {
+			Expect(Abs(m)).To(Equal(expect))
+		},
+		Entry("zero", &money.Money{}, &money.Money{}),
+		Entry("positive", &money.Money{Units: 1, Nanos: 230000000}, &money.Money{Units: 1, Nanos: 230000000}),
+		Entry("negative", &money.Money{Units: -1, Nanos: -230000000}, &money.Money{Units: 1, Nanos: 230000000}),
+	)
+})
+
+var _ = Describe("func Neg()", func() {
+	DescribeTable(
+		"it returns an amount with the inverse magnitude",
+		func(m, expect *money.Money) {
+			Expect(Neg(m)).To(Equal(expect))
+		},
+		Entry("zero", &money.Money{}, &money.Money{}),
+		Entry("positive", &money.Money{Units: 1, Nanos: 230000000}, &money.Money{Units: -1, Nanos: -230000000}),
+		Entry("negative", &money.Money{Units: -1, Nanos: -230000000}, &money.Money{Units: 1, Nanos: 230000000}),
+	)
+})
+
+var _ = Describe("func Add()", func() {
+	It("returns a + b", func() {
+		a := &money.Money{CurrencyCode: "XYZ", Units: 1, Nanos: 230000000}
+		b := &money.Money{CurrencyCode: "XYZ", Units: 3, Nanos: 450000000}
+		x := &money.Money{CurrencyCode: "XYZ", Units: 4, Nanos: 680000000}
+		Expect(Add(a, b)).To(Equal(x))
+	})
+
+	It("panics if the amounts do not have the same currency", func() {
+		Expect(func() {
+			a := &money.Money{CurrencyCode: "XYZ"}
+			b := &money.Money{CurrencyCode: "ABC"}
+			Add(a, b)
+		}).To(PanicWith("can not operate on amounts in differing currencies (XYZ vs ABC)"))
+	})
+})
+
+var _ = Describe("func Sub()", func() {
+	It("returns a - b", func() {
+		a := &money.Money{CurrencyCode: "XYZ", Units: 1, Nanos: 230000000}
+		b := &money.Money{CurrencyCode: "XYZ", Units: 3, Nanos: 450000000}
+		x := &money.Money{CurrencyCode: "XYZ", Units: -2, Nanos: -220000000}
+		Expect(Sub(a, b)).To(Equal(x))
+	})
+
+	It("panics if the amounts do not have the same currency", func() {
+		Expect(func() {
+			a := &money.Money{CurrencyCode: "XYZ"}
+			b := &money.Money{CurrencyCode: "ABC"}
+			Sub(a, b)
+		}).To(PanicWith("can not operate on amounts in differing currencies (XYZ vs ABC)"))
+	})
+})
+
+var _ = Describe("func Sum()", func() {
+	It("returns the sum of all amounts", func() {
+		Expect(
+			Sum(
+				&money.Money{CurrencyCode: "XYZ", Units: 10, Nanos: 1},
+				&money.Money{CurrencyCode: "XYZ", Units: 20, Nanos: 2},
+				&money.Money{CurrencyCode: "XYZ", Units: 30, Nanos: 999999999},
+			),
+		).To(Equal(
+			&money.Money{CurrencyCode: "XYZ", Units: 61, Nanos: 2},
+		))
+	})
+
+	It("panics if no amounts are provided", func() {
+		Expect(func() {
+			Sum()
+		}).To(PanicWith("at least one amount must be provided"))
+	})
+
+	It("panics if the amounts do not have the same currency", func() {
+		Expect(func() {
+			Sum(
+				&money.Money{CurrencyCode: "XYZ"},
+				&money.Money{CurrencyCode: "ABC"},
+			)
+		}).To(PanicWith("can not operate on amounts in differing currencies (XYZ vs ABC)"))
+	})
+})

--- a/protomoney/normalize.go
+++ b/protomoney/normalize.go
@@ -1,0 +1,97 @@
+package protomoney
+
+import (
+	"fmt"
+
+	"github.com/dogmatiq/dosh/internal/currency"
+	"google.golang.org/genproto/googleapis/type/money"
+)
+
+// nanosPerUnit is the number of "nano units" in each unit.
+const nanosPerUnit = 1_000_000_000
+
+// Validate returns an error if m is invalid.
+func Validate(m *money.Money) error {
+	if err := currency.ValidateCode(m.CurrencyCode); err != nil {
+		return err
+	}
+
+	return checkSignsAgree(m)
+}
+
+// Normalize validates m, and returns its normalized version if it is
+// valid.
+//
+// Within a normalized value the nanos component is guaranteed to be less than
+// one whole unit.
+//
+// m itself is never mutated. If it is already normalized it is returned
+// unchanged; otherwise a normalized clone is returned.
+func Normalize(m *money.Money) (*money.Money, error) {
+	if err := Validate(m); err != nil {
+		return nil, err
+	}
+
+	return normalize(m), nil
+}
+
+// isNormalized returns true if the units and nanos components of m are already
+// normalized.
+func isNormalized(m *money.Money) bool {
+	assertSignsAgree(m)
+	return -nanosPerUnit < m.Nanos && m.Nanos < nanosPerUnit
+}
+
+// normalizeInPlace normalizes the units and nanos components of m such that
+// m.Nanos is guaranteed to contain less than one whole unit.
+func normalizeInPlace(m *money.Money) {
+	if !isNormalized(m) {
+		m.Units += int64(m.Nanos) / nanosPerUnit
+		m.Nanos %= nanosPerUnit
+	}
+}
+
+// normalize returns m with normalized units and nanos components, or panics
+// if unable to do so.
+func normalize(m *money.Money) *money.Money {
+	if isNormalized(m) {
+		return m
+	}
+
+	return &money.Money{
+		CurrencyCode: m.CurrencyCode,
+		Units:        m.Units + (int64(m.Nanos) / nanosPerUnit),
+		Nanos:        m.Nanos % nanosPerUnit,
+	}
+}
+
+// assertSameCurrency panics if a and b do not have the same currency.
+func assertSameCurrency(a, b *money.Money) {
+	if a.CurrencyCode != b.CurrencyCode {
+		panic(fmt.Sprintf(
+			"can not operate on amounts in differing currencies (%s vs %s)",
+			a.CurrencyCode,
+			b.CurrencyCode,
+		))
+	}
+}
+
+// assertSignsAgree panics if the signs of m.Units and m.Nanos do not agree.
+func assertSignsAgree(m *money.Money) {
+	if err := checkSignsAgree(m); err != nil {
+		panic(err)
+	}
+}
+
+// checkSignsAgree panics if the signs of m.Units and m.Nanos do not agree.
+func checkSignsAgree(m *money.Money) error {
+	if (m.Units > 0 && m.Nanos < 0) || (m.Units < 0 && m.Nanos > 0) {
+		return fmt.Errorf(
+			"sign of units component (%d) does not agree with sign of nanos component (%d)",
+			m.Units,
+			m.Nanos,
+		)
+	}
+
+	return nil
+}

--- a/protomoney/normalize.go
+++ b/protomoney/normalize.go
@@ -83,7 +83,8 @@ func assertSignsAgree(m *money.Money) {
 	}
 }
 
-// checkSignsAgree panics if the signs of m.Units and m.Nanos do not agree.
+// checkSignsAgree returns an error if the signs of m.Units and m.Nanos do not
+// agree.
 func checkSignsAgree(m *money.Money) error {
 	if (m.Units > 0 && m.Nanos < 0) || (m.Units < 0 && m.Nanos > 0) {
 		return fmt.Errorf(

--- a/protomoney/normalize_test.go
+++ b/protomoney/normalize_test.go
@@ -1,0 +1,64 @@
+package protomoney_test
+
+import (
+	. "github.com/dogmatiq/dosh/protomoney"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"google.golang.org/genproto/googleapis/type/money"
+)
+
+var _ = Describe("func Validate()", func() {
+	DescribeTable(
+		"it returns nil if the amount is valid",
+		func(m *money.Money) {
+			err := Validate(m)
+			Expect(err).ShouldNot(HaveOccurred())
+		},
+		Entry("zero", &money.Money{CurrencyCode: "XYZ"}),
+		Entry("positive units", &money.Money{CurrencyCode: "XYZ", Units: 1}),
+		Entry("positive nanos", &money.Money{CurrencyCode: "XYZ", Nanos: 1}),
+		Entry("positive units & nanos", &money.Money{CurrencyCode: "XYZ", Units: 1, Nanos: 1}),
+		Entry("negative units", &money.Money{CurrencyCode: "XYZ", Units: -1}),
+		Entry("negative nanos", &money.Money{CurrencyCode: "XYZ", Nanos: -1}),
+		Entry("negative units & nanos", &money.Money{CurrencyCode: "XYZ", Units: -1, Nanos: -1}),
+	)
+
+	DescribeTable(
+		"it returns an error if the amount is invalid",
+		func(m *money.Money, expect string) {
+			err := Validate(m)
+			Expect(err).To(MatchError(expect))
+		},
+		Entry("empty currency code", &money.Money{}, "currency code is empty, codes must consist only of 3 or more uppercase ASCII letters"),
+		Entry("invalid currency code", &money.Money{CurrencyCode: "X"}, "currency code (X) is invalid, codes must consist only of 3 or more uppercase ASCII letters"),
+		Entry("positive units, negative nanos", &money.Money{CurrencyCode: "XYZ", Units: +1, Nanos: -1}, "sign of units component (1) does not agree with sign of nanos component (-1)"),
+		Entry("negative units, positive nanos", &money.Money{CurrencyCode: "XYZ", Units: -1, Nanos: +1}, "sign of units component (-1) does not agree with sign of nanos component (1)"),
+	)
+})
+
+var _ = Describe("func Normalize()", func() {
+	DescribeTable(
+		"it normalizes the amount",
+		func(m, expect *money.Money) {
+			n, err := Normalize(m)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(n).To(Equal(expect))
+		},
+		Entry("normalized", &money.Money{CurrencyCode: "XYZ", Units: 1, Nanos: 999999999}, &money.Money{CurrencyCode: "XYZ", Units: 1, Nanos: 999999999}),
+		Entry("denormalized, overflow", &money.Money{CurrencyCode: "XYZ", Units: 1, Nanos: 1500000000}, &money.Money{CurrencyCode: "XYZ", Units: 2, Nanos: 500000000}),
+		Entry("denormalized, underflow", &money.Money{CurrencyCode: "XYZ", Units: 1, Nanos: 1500000000}, &money.Money{CurrencyCode: "XYZ", Units: 2, Nanos: 500000000}),
+	)
+
+	DescribeTable(
+		"it returns an error if the amount is invalid",
+		func(m *money.Money, expect string) {
+			_, err := Normalize(m)
+			Expect(err).To(MatchError(expect))
+		},
+		Entry("empty currency code", &money.Money{}, "currency code is empty, codes must consist only of 3 or more uppercase ASCII letters"),
+		Entry("invalid currency code", &money.Money{CurrencyCode: "X"}, "currency code (X) is invalid, codes must consist only of 3 or more uppercase ASCII letters"),
+		Entry("positive units, negative nanos", &money.Money{CurrencyCode: "XYZ", Units: +1, Nanos: -1}, "sign of units component (1) does not agree with sign of nanos component (-1)"),
+		Entry("negative units, positive nanos", &money.Money{CurrencyCode: "XYZ", Units: -1, Nanos: +1}, "sign of units component (-1) does not agree with sign of nanos component (1)"),
+	)
+})


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds the `protomoney` package, which provides comparison and (basic) mathematical operations directly on the protocol buffers well-known `Money` type.

#### Why make this change?

I am anticipating heavy use of this type inside business logic, especially aggregates where you have to deal with comparing and adding/subtracting monetary values based on `*money.Money` values inside messages and aggregate roots. (Think `ApplyEvent()`, etc).

This lets you do so without the overhead of converting to a `dosh.Amount`, where possible.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
