### PR TITLE
add protomoney Sub fix

### DIFF
--- a/protomoney/math.go
+++ b/protomoney/math.go
@@ -51,11 +51,22 @@ func Add(a, b *money.Money) *money.Money {
 // It panics if a and b do not use the same currency.
 func Sub(a, b *money.Money) *money.Money {
 	assertSameCurrency(a, b)
+	units := a.Units - b.Units
+	nanos := a.Nanos - b.Nanos
+
+	if units > 0 && nanos < 0 {
+		nanos = nanosPerUnit + nanos
+		units--
+	}
+
+	if units < 0 && nanos > 0 {
+		nanos = -nanos
+	}
 
 	m := &money.Money{
 		CurrencyCode: a.CurrencyCode,
-		Units:        a.Units - b.Units,
-		Nanos:        a.Nanos - b.Nanos,
+		Units:        units,
+		Nanos:        nanos,
 	}
 
 	normalizeInPlace(m)

--- a/protomoney/math.go
+++ b/protomoney/math.go
@@ -60,7 +60,8 @@ func Sub(a, b *money.Money) *money.Money {
 	}
 
 	if units < 0 && nanos > 0 {
-		nanos = -nanos
+		nanos = -(nanosPerUnit - nanos)
+		units++
 	}
 
 	m := &money.Money{

--- a/protomoney/math_test.go
+++ b/protomoney/math_test.go
@@ -77,7 +77,7 @@ var _ = Describe("func Sub()", func() {
 			"negative unit and positive nanos are normalized",
 			&money.Money{CurrencyCode: "XYZ", Units: 1, Nanos: 200000000},
 			&money.Money{CurrencyCode: "XYZ", Units: 2, Nanos: 100000000},
-			&money.Money{CurrencyCode: "XYZ", Units: -1, Nanos: -100000000},
+			&money.Money{CurrencyCode: "XYZ", Units: 0, Nanos: -900000000},
 		),
 	)
 })

--- a/protomoney/math_test.go
+++ b/protomoney/math_test.go
@@ -50,20 +50,36 @@ var _ = Describe("func Add()", func() {
 })
 
 var _ = Describe("func Sub()", func() {
-	It("returns a - b", func() {
-		a := &money.Money{CurrencyCode: "XYZ", Units: 1, Nanos: 230000000}
-		b := &money.Money{CurrencyCode: "XYZ", Units: 3, Nanos: 450000000}
-		x := &money.Money{CurrencyCode: "XYZ", Units: -2, Nanos: -220000000}
-		Expect(Sub(a, b)).To(Equal(x))
-	})
-
-	It("panics if the amounts do not have the same currency", func() {
-		Expect(func() {
-			a := &money.Money{CurrencyCode: "XYZ"}
-			b := &money.Money{CurrencyCode: "ABC"}
-			Sub(a, b)
-		}).To(PanicWith("can not operate on amounts in differing currencies (XYZ vs ABC)"))
-	})
+	DescribeTable(
+		"returns a - b",
+		func(a, b, x *money.Money) {
+			Expect(Sub(a, b)).To(Equal(x))
+		},
+		Entry(
+			"negative",
+			&money.Money{CurrencyCode: "XYZ", Units: 1, Nanos: 230000000},
+			&money.Money{CurrencyCode: "XYZ", Units: 3, Nanos: 450000000},
+			&money.Money{CurrencyCode: "XYZ", Units: -2, Nanos: -220000000},
+		),
+		Entry(
+			"positive",
+			&money.Money{CurrencyCode: "XYZ", Units: 3, Nanos: 450000000},
+			&money.Money{CurrencyCode: "XYZ", Units: 1, Nanos: 230000000},
+			&money.Money{CurrencyCode: "XYZ", Units: 2, Nanos: 220000000},
+		),
+		Entry(
+			"positive unit and negative nanos are normalized",
+			&money.Money{CurrencyCode: "XYZ", Units: 40, Nanos: 0},
+			&money.Money{CurrencyCode: "XYZ", Units: 0, Nanos: 450000000},
+			&money.Money{CurrencyCode: "XYZ", Units: 39, Nanos: 550000000},
+		),
+		Entry(
+			"negative unit and positive nanos are normalized",
+			&money.Money{CurrencyCode: "XYZ", Units: 1, Nanos: 200000000},
+			&money.Money{CurrencyCode: "XYZ", Units: 2, Nanos: 100000000},
+			&money.Money{CurrencyCode: "XYZ", Units: -1, Nanos: -100000000},
+		),
+	)
 })
 
 var _ = Describe("func Sum()", func() {


### PR DESCRIPTION
#### What change does this introduce?

fix subtraction errors in `Sub` func in `protomoney` pkg

#### Why make this change?
currently the below example will panic
```golang
FortyDollarsUSD := &money.Money{
	CurrencyCode: "USD",
	Units:        40,
	Nanos:        0,
}
FiftyCentsUSD := &money.Money{
	CurrencyCode: "USD",
	Units:        0,
	Nanos:        500_000_000,
}

value := protomoney.Sub(FortyDollarsUSD, FiftyCentsUSD)
```

#### Is there anything you are unsure about?

Originally I had converted `a` and `b` to `Amounts` within the `Sub()` func. 

But was unsure if we were avoiding that as no other math funcs use the main `dosh` pkg 🤷‍♂️ 

#### What issues does this relate to?

Maths is broken